### PR TITLE
enhancement: move/up down history if on first/last line of prompt

### DIFF
--- a/widgets.zsh
+++ b/widgets.zsh
@@ -83,11 +83,11 @@ function zhm_move_left {
 }
 
 function zhm_move_up {
-  zle up-line
+  zle up-line-or-history
 }
 
 function zhm_move_down {
-  zle down-line
+  zle down-line-or-history
 }
 
 function zhm_move_next_word_start {


### PR DESCRIPTION
Just a little enhancement:

I replaced `zle down-line/up-line` with the more elborated functions `down-line-or-history/up-line-or-history`. Thus, you move the zsh history automatically up/down in `hnor` mode if you're on the first/last line of the current prompt and press `k`/`j`.

That behavior is copied from `vicmd` mode and I think its very intuitive. Merge it if you like :wink: 