### PR TITLE
feat: add nix package and flake

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,26 +94,26 @@ Add the input to your flake:
 }
 ```
 
-#### Source in ZSH config:
+#### Install using NixOS ZSH module
 
 ```nix
 {
   programs.zsh = {
     interactiveShellInit = ''
-      source ${pkgs.}/share/zsh-helix-mode/zsh-helix-mode.plugin.zsh
+      source ${pkgs.zsh-helix-mode}/share/zsh-helix-mode/zsh-helix-mode.plugin.zsh
     '';
   };
 }
 ```
 
-#### Install using Home-Manager:
+#### Install using Home-Manager module
 
 ```nix
 {
   programs.zsh = {
     plugins = [
       {
-        name = "helix-mode";
+        name = "zsh-helix-mode";
         src = pkgs.zsh-helix-mode;
         file = "share/zsh-helix-mode/zsh-helix-mode.plugin.zsh";
       }

--- a/README.md
+++ b/README.md
@@ -82,10 +82,42 @@ source ${zsh-helix-mode}/zsh-helix-mode.plugin.zsh
 ```
 
 ### [Nix](https://nixos.org/) ([flake](https://nix.dev/concepts/flakes.html))
+
+Add the input to your flake:
+
 ```nix
 {
   inputs = {
-    zsh-helix-mode.url = "github:multirious/zsh-helix-mode/main"
+    zsh-helix-mode.url = "github:multirious/zsh-helix-mode/main";
+    zsh-helix-mode.inputs.nixpkgs.follows = "nixpkgs";
+  };
+}
+```
+
+#### Source in ZSH config:
+
+```nix
+{
+  programs.zsh = {
+    interactiveShellInit = ''
+      source ${pkgs.}/share/zsh-helix-mode/zsh-helix-mode.plugin.zsh
+    '';
+  };
+}
+```
+
+#### Install using Home-Manager:
+
+```nix
+{
+  programs.zsh = {
+    plugins = [
+      {
+        name = "helix-mode";
+        src = pkgs.zsh-helix-mode;
+        file = "share/zsh-helix-mode/zsh-helix-mode.plugin.zsh";
+      }
+    ];
   };
 }
 ```

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,26 @@
+{ lib
+, stdenvNoCC
+}:
+stdenvNoCC.mkDerivation
+{
+  pname = "zsh-helix-mode";
+  version = "git";
+
+  src = ./.;
+
+  strictDeps = true;
+  dontBuild = true;
+
+  installPhase = ''
+    mkdir -p $out/share/zsh-helix-mode
+    cp *.zsh $out/share/zsh-helix-mode/
+  '';
+
+  meta = with lib; {
+    description = "Helix keybinding for Z Shell";
+    homepage = "https://github.com/Multirious/zsh-helix-mode";
+    license = licenses.mit;
+    platforms = platforms.all;
+    maintainers = with maintainers; [ ];
+  };
+}

--- a/default.nix
+++ b/default.nix
@@ -1,8 +1,8 @@
-{ lib
-, stdenvNoCC
-}:
-stdenvNoCC.mkDerivation
 {
+  lib,
+  stdenvNoCC,
+}:
+stdenvNoCC.mkDerivation {
   pname = "zsh-helix-mode";
   version = "git";
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1758070117,
+        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
+  };
+
+  outputs = { self, nixpkgs }: {
+    packages = nixpkgs.lib.genAttrs [
+      "x86_64-linux"
+      "aarch64-linux"
+      "x86_64-darwin"
+      "aarch64-darwin"
+    ]
+      (system: rec {
+        zsh-helix-mode = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
+        default = zsh-helix-mode;
+      });
+
+    overlays = {
+      default = (final: prev: {
+        zsh-helix-mode = self.packages.${prev.system}.zsh-helix-mode;
+      });
+
+    };
+  };
+
+}

--- a/flake.nix
+++ b/flake.nix
@@ -3,24 +3,30 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-25.05";
   };
 
-  outputs = { self, nixpkgs }: {
-    packages = nixpkgs.lib.genAttrs [
-      "x86_64-linux"
-      "aarch64-linux"
-      "x86_64-darwin"
-      "aarch64-darwin"
-    ]
-      (system: rec {
-        zsh-helix-mode = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
-        default = zsh-helix-mode;
-      });
+  outputs =
+    { self, nixpkgs }:
+    {
+      packages =
+        nixpkgs.lib.genAttrs
+          [
+            "x86_64-linux"
+            "aarch64-linux"
+            "x86_64-darwin"
+            "aarch64-darwin"
+          ]
+          (system: rec {
+            zsh-helix-mode = nixpkgs.legacyPackages.${system}.callPackage ./default.nix { };
+            default = zsh-helix-mode;
+          });
 
-    overlays = {
-      default = (final: prev: {
-        zsh-helix-mode = self.packages.${prev.system}.zsh-helix-mode;
-      });
+      overlays = {
+        default = (
+          final: prev: {
+            zsh-helix-mode = self.packages.${prev.system}.zsh-helix-mode;
+          }
+        );
 
+      };
     };
-  };
 
 }


### PR DESCRIPTION
Hi I wrote a simple package definition and flake.

This resolves #23

The flake exposes the package as `zsh-helix-mode` and `default`, as well as an overlay containing the package, for easy integration with system configs.

I also updated the README with a guide to how to use the flake, feel free to rewrite it  to fit with your style! 
I tried to describe the two ways to install it, with and without home manager, but Im not sure if I communicated it effectively :)

I also think the non-flake section could be update with something like:
```nix
with (import <nixpkgs> {});
let
  zsh-helix-mode = callPackage (builtins.fetchGit {
     url = "https://github.com/Multiritious/zsh-helix-mode";
     rev = "...";
   }) {};
in
''
source ${zsh-helix-mode}/zsh-helix-mode.plugin.zsh
''
```
since it should be able to import the `default.nix` file from the repo which contains the package definition, but I haven't tested it.