### PR TITLE
Fix capitalization in Nix `fetchFromGitHub` in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ plugins=(zsh-helix-mode)
 ### [Nix](https://nixos.org/) (non-flake)
 ```nix
 let
-  zsh-helix-mode = pkgs.fetchFromGithub {
+  zsh-helix-mode = pkgs.fetchFromGitHub {
     owner = "multirious";
     repo = "zsh-helix-mode";
     rev = "...";


### PR DESCRIPTION
The correct capitalization is fetchFromGitHub.
Source: https://nixos.org/manual/nixpkgs/stable/#fetchfromgithub

Nix will automatically give you an error "You meant fetchFromGitHub, with a capital H", but this will save Nix users a step.